### PR TITLE
cast the result of a isPlural function call to number

### DIFF
--- a/puttext.js
+++ b/puttext.js
@@ -63,7 +63,7 @@
                              {num: num, msg1: msg1, trans: trans});
             }
 
-            return trans[isPlural(num)];
+            return trans[+isPlural(num)];
         }
 
         return function(messages) {


### PR DESCRIPTION
By default, in gettext, plural form header for french looks like

```
"Plural-Forms: nplurals=2; plural=(n > 1);\n"
```

That means that the `isPlural` function return `Boolean` type, instead of `Number`(for getting by index).
So, I added simple cast to number.
